### PR TITLE
Make project Vercel deployable

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,2 @@
+const app = require('../index');
+module.exports = app;

--- a/index.js
+++ b/index.js
@@ -106,6 +106,10 @@ app.use("/api-docs", swaggerUI.serve, swaggerUI.setup(swaggerDocument));
 app.use(notFound);
 app.use(errorHandler);
 
-app.listen(PORT, () => {
-  console.log(`Server is running at PORT  ${PORT} `);
-});
+module.exports = app;
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server is running at PORT  ${PORT} `);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "server": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -2,16 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "index.js",
-      "use": "node_modules"
+      "src": "api/**/*.js",
+      "use": "@vercel/node"
     }
   ],
   "routes": [
     {
-      // Specify which paths will route to a destination using a regex
       "src": "/(.*)",
-      // Specify the paths' destination
-      "dest": "index.js"
+      "dest": "api/index.js"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- enable Express to run on Vercel by exporting the app
- add Vercel entry in `api/index.js`
- configure Vercel build settings
- provide a start script in `package.json`

## Testing
- `npm test`
- `npm run server` *(fails: Mongoose requires a DB url)*

------
https://chatgpt.com/codex/tasks/task_b_688b75c0aca88325a153e1a5d6936cef